### PR TITLE
Remove quickcheck dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 
 Other improvements:
 
+- Remove the __quickcheck__ dependency from the package. Add __gen__ dependency and `Gen` modules. Add the __quickcheck__ dependency to the test `spago-dev.dhall`. (#7 by @jamesdbrock)
 
 ## [v2.0.0](https://github.com/purescript-contrib/purescript-int64/releases/tag/v1.0.0) - 2022-06-02
 

--- a/spago-dev.dhall
+++ b/spago-dev.dhall
@@ -15,6 +15,7 @@ conf //
   [ "spec"
   , "aff"
   , "quickcheck-laws"
+  , "quickcheck"
   , "assert"
   , "arrays"
   , "foldable-traversable"

--- a/spago.dhall
+++ b/spago.dhall
@@ -7,7 +7,7 @@
   , "nullable"
   , "functions"
   , "maybe"
-  , "quickcheck"
+  , "gen"
   , "unsafe-coerce"
   ]
 , packages = ./packages.dhall

--- a/src/Data/Int64.Gen.purs
+++ b/src/Data/Int64.Gen.purs
@@ -1,0 +1,39 @@
+module Data.Int64.Gen
+  ( chooseInt64
+  ) where
+
+import Prelude
+
+import Control.Monad.Gen (class MonadGen, chooseInt)
+import Data.Int64 (Int64, fromLowHighBits, toSigned, toUnsigned)
+import Data.UInt64 (UInt64, rem)
+
+topsigned :: UInt64
+topsigned = toUnsigned top
+
+-- | map
+-- | signed bottom → zero
+-- | zero → signed top + 1
+-- | signed top -> unsigned top
+mapToUInt64 :: Int64 -> UInt64
+mapToUInt64 x = if x >= zero then toUnsigned x + topsigned + one else toUnsigned (top + x) + one
+
+-- | map
+-- | zero → signed bottom
+-- | signed top + 1 → zero
+-- | unsigned top → signed top
+mapToInt64 :: UInt64 -> Int64
+mapToInt64 x = if x > topsigned then toSigned (x - topsigned - one) else toSigned x - top - one
+
+chooseInt64 :: forall m. MonadGen m => Int64 -> Int64 -> m Int64
+chooseInt64 a b = do
+  random <- fromLowHighBits <$> chooseInt bottom top <*> chooseInt bottom top
+  -- We cannot subtract an Int64 from a greater Int64. But we can subtract a
+  -- UInt64 from a greater UInt64. So map the random Int64 to a UInt64,
+  -- constrain it between a and b, then map it back.
+  let
+    randomu = mapToUInt64 random
+    au = mapToUInt64 a
+    bu = mapToUInt64 b
+  pure $ mapToInt64 $ (randomu `rem` (bu - au)) + au
+

--- a/src/Data/Int64.purs
+++ b/src/Data/Int64.purs
@@ -81,7 +81,6 @@ import Data.Int (Parity, Radix, decimal)
 import Data.Int64.Internal as Internal
 import Data.Maybe (Maybe)
 import Data.UInt64 (UInt64)
-import Test.QuickCheck (class Arbitrary)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Signed two’s-complement 64-bit integer.
@@ -98,8 +97,11 @@ derive newtype instance Bounded Int64
 derive newtype instance Semiring Int64
 derive newtype instance Ring Int64
 derive newtype instance CommutativeRing Int64
+
+-- | The `EuclideanRing` instance provides a `mod` operator which
+-- | is only lawful if the *divisor* is in the `Int` range,
+-- | *-2³¹ ≤ divisor ≤ 2³¹⁻¹*.
 derive newtype instance EuclideanRing Int64
-derive newtype instance Arbitrary Int64
 
 -- | Creates an `Int64` from an `Int` value.
 fromInt :: Int -> Int64

--- a/src/Data/Int64/Internal.purs
+++ b/src/Data/Int64/Internal.purs
@@ -106,7 +106,6 @@ import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
 import Data.Ord (abs)
-import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 
 foreign import data Signedness :: Type
 
@@ -187,7 +186,8 @@ instance euclideanRingLong'Signed :: EuclideanRing (Long' Signed) where
   degree = Int.floor <<< toNumber <<< abs
   div l1 l2 =
     (l1 - (l1 `mod` l2)) `quot` l2
-
+  -- https://github.com/purescript/purescript-prelude/blob/f4cad0ae8106185c9ab407f43cf9abf05c256af4/src/Data/EuclideanRing.js#L14
+  -- https://en.m.wikipedia.org/wiki/Modulo_operation
   mod l1 l2 =
     let
       l2' = abs l2
@@ -198,9 +198,6 @@ instance euclideanRingLong'Unsigned :: EuclideanRing (Long' Unsigned) where
   degree = Int.floor <<< toNumber <<< abs
   div = quot
   mod = rem
-
-instance arbitraryLong' :: SInfo s => Arbitrary (Long' s) where
-  arbitrary = fromLowHighBits <$> arbitrary <*> arbitrary
 
 -- Constructors
 
@@ -488,6 +485,8 @@ foreign import lessThan_ :: Long -> Fn1 Long Boolean
 foreign import lessThanOrEqual_ :: Long -> Fn1 Long Boolean
 
 -- | Returns this Long modulo the specified.
+-- |
+-- | The foreign implementation only works when the divisor is in the Int range.
 foreign import modulo_ :: Long -> Fn1 Long Long
 
 -- | Returns the product of this and the specified Long.

--- a/src/Data/UInt64.Gen.purs
+++ b/src/Data/UInt64.Gen.purs
@@ -1,0 +1,12 @@
+module Data.UInt64.Gen
+  ( chooseUInt64
+  ) where
+
+import Prelude
+import Control.Monad.Gen (class MonadGen, chooseInt)
+import Data.UInt64 (UInt64, fromLowHighBits, rem)
+
+chooseUInt64 :: forall m. MonadGen m => UInt64 -> UInt64 -> m UInt64
+chooseUInt64 a b = do
+  random <- fromLowHighBits <$> chooseInt bottom top <*> chooseInt bottom top
+  pure $ (random `rem` (b - a)) + a

--- a/src/Data/UInt64.purs
+++ b/src/Data/UInt64.purs
@@ -69,7 +69,6 @@ import Prelude
 import Data.Int (Parity, Radix, decimal)
 import Data.Int64.Internal as Internal
 import Data.Maybe (Maybe)
-import Test.QuickCheck (class Arbitrary)
 
 -- | Unsigned 64-bit integer.
 newtype UInt64 = UInt64 (Internal.Long' Internal.Unsigned)
@@ -86,7 +85,6 @@ derive newtype instance Semiring UInt64
 derive newtype instance Ring UInt64
 derive newtype instance CommutativeRing UInt64
 derive newtype instance EuclideanRing UInt64
-derive newtype instance Arbitrary UInt64
 
 -- | Creates a `UInt64` from an `Int` value.
 fromInt :: Int -> Maybe UInt64


### PR DESCRIPTION
Remove the __quickcheck__ dependency from the package. Add __gen__ dependency and `Gen` modules. Add the __quickcheck__ dependency to the test `spago-dev.dhall`.

Resolves #6

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
